### PR TITLE
add nose as test_suite in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,14 @@ setup(
     author_email='dcsrd@dl.trendmicro.com',
     packages=find_packages(exclude=("tests", "tests.*", "bin", "bin.*")),
     include_package_data=True,
+	test_suite = 'nose.collector',
     zip_safe=False,
     install_requires=[
         'Flask>=0.10.1',
         'boto3>=1.1.0',
         'mock>=1.1.2',
         'Flask-API>=0.6.3',
-        'Flask-HTTPAuth'
+        'Flask-HTTPAuth',
+		'nose'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     author_email='dcsrd@dl.trendmicro.com',
     packages=find_packages(exclude=("tests", "tests.*", "bin", "bin.*")),
     include_package_data=True,
-	test_suite = 'nose.collector',
+    test_suite = 'nose.collector',
     zip_safe=False,
     install_requires=[
         'Flask>=0.10.1',
@@ -31,6 +31,6 @@ setup(
         'mock>=1.1.2',
         'Flask-API>=0.6.3',
         'Flask-HTTPAuth',
-		'nose'
+        'nose'
     ],
 )


### PR DESCRIPTION
Hi @hidetosaito,

Below steps are for the case if you're using virtualenv with nose:

```
$ virtualenv --no-site-packages my_env
$ source my_env/bin/activate  
$ pip install -r requirements.txt  
```

Then you might be able to run `python setup.py test` to perform test.

Please feel free to let me know if the problem still persist :-)

Thanks,
Chloe
