### PR TITLE
add cache implementation

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,6 +21,13 @@ class ProductionConfig(Config):
     # sqs
     SQS_REGIOM = 'us-west-1'
     SQS_NAME = 'QATaskQueue-Staging'
+    
+    # cache
+    # http://pythonhosted.org/Flask-Cache/#configuring-flask-cache
+    CACHE_TYPE = 'memcached'
+    CACHE_MEMCACHED_SERVERS = ''
+    CACHE_MEMCACHED_USERNAME = ''
+    CACHE_MEMCACHED_PASSWORD = ''
 
 
 class DevelopmentConfig(Config):
@@ -37,6 +44,9 @@ class DevelopmentConfig(Config):
     # sqs
     SQS_REGIOM = 'us-east-1'
     SQS_NAME = 'QATaskQueue-POC'
+    
+    # cache
+    CACHE_TYPE = 'simple'
 
 
 class DevelopmentContainerConfig(DevelopmentConfig):
@@ -61,3 +71,6 @@ class TestConfig(Config):
     # sqs
     SQS_REGIOM = 'us-east-1'
     SQS_NAME = 'test-POC'
+    
+    # cache
+    CACHE_TYPE = 'simple'

--- a/dcsqa/app.py
+++ b/dcsqa/app.py
@@ -3,6 +3,8 @@
 #
 
 from flask import Flask
+from flask.ext.cache import Cache
+
 from criteria import criteria_blueprint
 from raw import raw_blueprint
 from result import result_blueprint
@@ -13,6 +15,7 @@ app = Flask(__name__)
 
 def create_app(app_name='dcsqa', config='config.DevelopmentConfig'):
     app.config.from_object(config)
+    app.cache = Cache(app) 
 
     # register blueprint for each restful entry
     # http://flask.pocoo.org/docs/0.10/blueprints/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ Flask==0.10.1
 mock==1.1.2
 Flask-API==0.6.3
 Flask-HTTPAuth
+Flask-Cache
 # using moto#a63d7486173f3b717d35310ede5acfa87809deb2 for https://github.com/spulec/moto/issues/374
 https://github.com/spulec/moto/archive/master.zip


### PR DESCRIPTION
Hi @msfuko 

i'd like to adopt Flask Cache (https://pythonhosted.org/Flask-Cache/) into this Reference Implementation. for the _DevelopmentConfig_ and _TestConfig_ it uses Simple(on-memory cache), for the _ProductionConfig_ it uses memcached (not confirmed yet, redis also fine; as long as AWS ElastiCache supports)

I believe it would help to reduce DynamoDB query and improve the response throughput, please take a look.

By the way, originally i tried to use decorator  (@current_app.cache.cached) on criteria methods, however it raise an exception _RuntimeError: working outside of application context_ due to inside of Blueprint, i referred to your unit testing to solve similar issue, but i just use programatic way :-p
